### PR TITLE
fix ConcurrentModificationException in MockServerContext.kt

### DIFF
--- a/mock-server-core/src/main/kotlin/io/github/infeez/kotlinmockserver/dsl/http/context/MockServerContext.kt
+++ b/mock-server-core/src/main/kotlin/io/github/infeez/kotlinmockserver/dsl/http/context/MockServerContext.kt
@@ -5,6 +5,7 @@ import io.github.infeez.kotlinmockserver.mock.MockConfiguration
 import io.github.infeez.kotlinmockserver.mockmodel.MockWebRequest
 import io.github.infeez.kotlinmockserver.server.Server
 import java.io.Closeable
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * The main class that implements the work of the mock server.
@@ -20,7 +21,7 @@ class MockServerContext(
     private val lazyMocks = mutableListOf<Lazy<Mock>>()
 
     val mocks by lazy {
-        mutableListOf<Mock>()
+        CopyOnWriteArrayList<Mock>()
     }
     private val requests = mutableMapOf<Int, MockWebRequest>()
 


### PR DESCRIPTION
mocks type  changed from mutableListOf() to CopyOnWriteArrayList<Mock>() in MockServerContext.kt

fixes
```
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1029)
	at java.util.ArrayList$Itr.next(ArrayList.java:982)
	at io.github.infeez.kotlinmockserver.dsl.http.context.MockServerContext$1.invoke(MockServerContext.kt:37)
	at io.github.infeez.kotlinmockserver.dsl.http.context.MockServerContext$1.invoke(MockServerContext.kt:15)
	at io.github.infeez.kotlinmockserver.server.OkHttpServer$1.dispatch(OkHttpServer.kt:38)
	at okhttp3.mockwebserver.MockWebServer$Http2SocketHandler.onStream(MockWebServer.kt:967)
	at rj0.c.runOnce(TaskQueue.kt:7)
	at okhttp3.internal.concurrent.TaskRunner.a(TaskRunner.kt:19)
	at okhttp3.internal.concurrent.TaskRunner$b.run(TaskRunner.kt:50)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
	at java.lang.Thread.run(Thread.java:1012) 
```

an exception occurs when more than 6 mocks are added in addAll lambda
